### PR TITLE
Add rounded CreateBubble form with native topic picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@react-native-community/masked-view": "^0.1.11",
+        "@react-native-picker/picker": "2.4.10",
         "@react-navigation/native": "^7.1.10",
         "@react-navigation/native-stack": "^7.3.14",
         "@supabase/supabase-js": "^2.49.9",
@@ -18,6 +19,7 @@
         "react-native": "0.79.2",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-pager-view": "6.7.1",
+        "react-native-paper": "5.10.2",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
@@ -1506,6 +1508,28 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@callstack/react-theme-provider": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.9.tgz",
+      "integrity": "sha512-tTQ0uDSCL0ypeMa8T/E9wAZRGKWj8kXP7+6RYgPTfOPs9N07C9xM8P02GJ3feETap4Ux5S69D9nteq9mEj86NA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider/node_modules/deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
@@ -2309,6 +2333,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.0",
+        "react-native": ">=0.57"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.10.tgz",
+      "integrity": "sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16",
         "react-native": ">=0.57"
       }
     },
@@ -6785,6 +6819,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7015,6 +7068,57 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-paper": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-5.10.2.tgz",
+      "integrity": "sha512-IFYH0CM22NUigHF7RLHGcrvW1/lq4EEgDSIxgcqU/y7WQ0kbuvJLRTCYOh0M4+cSRHQsI5CLHPWWy64FK/2UvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@callstack/react-theme-provider": "^3.0.9",
+        "color": "^3.1.2",
+        "use-latest-callback": "^0.1.5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": "*",
+        "react-native-vector-icons": "*"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-paper/node_modules/use-latest-callback": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.11.tgz",
+      "integrity": "sha512-8nhb73STSD/z3GTHklvNjL8F9wMOo0bj0AFnulpIYuFTm6aQlT3ZcNbXF2YurKImIY8+kpSFSDHZZyQmurGrhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/react-native-reanimated": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
@@ -7078,6 +7182,99 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-vector-icons": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.2.0.tgz",
+      "integrity": "sha512-n5HGcxUuVaTf9QJPs/W22xQpC2Z9u0nb0KgLPnVltP8vdUvOp6+R26gF55kilP/fV4eL4vsAHUqUjewppJMBOQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "fa-upgrade.sh": "bin/fa-upgrade.sh",
+        "fa5-upgrade": "bin/fa5-upgrade.sh",
+        "fa6-upgrade": "bin/fa6-upgrade.sh",
+        "generate-icon": "bin/generate-icon.js"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-native-vector-icons/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
-    "react-native-svg": "15.11.2"
+    "react-native-svg": "15.11.2",
+    "react-native-paper": "5.10.2",
+    "@react-native-picker/picker": "2.4.10"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,25 @@
 import React from 'react';
+import { Provider as PaperProvider, MD3DarkTheme } from 'react-native-paper';
 import RootNavigator from './navigation/RootNavigator';
 import { AuthProvider } from './context/AuthContext';
+
+const theme = {
+  ...MD3DarkTheme,
+  roundness: 24,
+  colors: {
+    ...MD3DarkTheme.colors,
+    primary: '#ffe46b',
+    background: '#111111',
+    surface: '#222222',
+  },
+};
 
 export default function App() {
   return (
     <AuthProvider>
-      <RootNavigator />
+      <PaperProvider theme={theme}>
+        <RootNavigator />
+      </PaperProvider>
     </AuthProvider>
   );
 }

--- a/src/components/CreateBubbleModal.tsx
+++ b/src/components/CreateBubbleModal.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { View, StyleSheet, Platform, ActionSheetIOS } from 'react-native';
+import { Modal, Portal, TextInput, Button, Surface } from 'react-native-paper';
+import { Picker } from '@react-native-picker/picker';
+
+export type CreateBubbleModalProps = {
+  visible: boolean;
+  onDismiss: () => void;
+  onSubmit?: (label: string, topic: string) => void;
+  topics: string[];
+};
+
+export default function CreateBubbleModal({ visible, onDismiss, onSubmit, topics }: CreateBubbleModalProps) {
+  const [label, setLabel] = useState('');
+  const [topic, setTopic] = useState('');
+
+  const handleSubmit = () => {
+    onSubmit?.(label.trim(), topic.trim());
+    setLabel('');
+    setTopic('');
+    onDismiss();
+  };
+
+  const openIOSPicker = () => {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: [...topics, 'Cancel'],
+        cancelButtonIndex: topics.length,
+      },
+      (index) => {
+        if (index < topics.length) {
+          setTopic(topics[index]);
+        }
+      },
+    );
+  };
+
+  return (
+    <Portal>
+      <Modal visible={visible} onDismiss={onDismiss} contentContainerStyle={styles.modal}>
+        <Surface style={styles.card} elevation={4}>
+          <TextInput
+            mode="outlined"
+            label="Label"
+            value={label}
+            onChangeText={setLabel}
+            style={styles.input}
+          />
+          {Platform.OS === 'ios' ? (
+            <TextInput
+              mode="outlined"
+              label="Topic"
+              placeholder="Select a topic"
+              value={topic}
+              onFocus={openIOSPicker}
+              style={styles.input}
+              showSoftInputOnFocus={false}
+            />
+          ) : (
+            <View style={styles.pickerWrapper}>
+              <Picker
+                selectedValue={topic}
+                onValueChange={(val) => setTopic(val)}
+                style={styles.picker}
+              >
+                <Picker.Item label="Select a topic" value="" />
+                {topics.map((t) => (
+                  <Picker.Item label={t} value={t} key={t} />
+                ))}
+              </Picker>
+            </View>
+          )}
+          <Button mode="contained" onPress={handleSubmit} style={styles.button} disabled={!label || !topic}>
+            Create
+          </Button>
+          <Button onPress={onDismiss} textColor="#ccc" style={styles.cancel}>Cancel</Button>
+        </Surface>
+      </Modal>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modal: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 400,
+    padding: 24,
+    borderRadius: 24,
+    backgroundColor: '#222',
+    overflow: 'visible',
+  },
+  input: {
+    marginBottom: 16,
+    backgroundColor: '#333',
+    borderRadius: 12,
+  },
+  pickerWrapper: {
+    marginBottom: 16,
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: '#333',
+  },
+  picker: {
+    color: '#fff',
+  },
+  button: {
+    borderRadius: 12,
+  },
+  cancel: {
+    marginTop: 8,
+  },
+});

--- a/src/screens/BubblesScreen.tsx
+++ b/src/screens/BubblesScreen.tsx
@@ -5,6 +5,8 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/RootNavigator';
 import { useAuth } from '../context/AuthContext';
 import Bubble, { BubbleData } from '../components/Bubble';
+import CreateBubbleModal from '../components/CreateBubbleModal';
+import { FAB } from 'react-native-paper';
 
 const { width, height } = Dimensions.get('window');
 const CENTER_X = width / 2;
@@ -18,6 +20,8 @@ export default function BubblesScreen() {
   const navigation = useNavigation<NavigationProp>();
   const { supabase } = useAuth();
   const [bubbles, setBubbles] = useState<BubbleData[]>([]);
+  const [creating, setCreating] = useState(false);
+  const topics = ['General', 'Tech', 'Art', 'Sport'];
 
   useEffect(() => {
     const loadBubbles = async () => {
@@ -51,6 +55,12 @@ export default function BubblesScreen() {
           onPress={(id) => navigation.navigate('Chat', { bubbleId: id })}
         />
       ))}
+      <CreateBubbleModal
+        visible={creating}
+        onDismiss={() => setCreating(false)}
+        topics={topics}
+      />
+      <FAB icon="plus" style={styles.fab} onPress={() => setCreating(true)} />
     </View>
   );
 }
@@ -59,5 +69,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#111111',
+  },
+  fab: {
+    position: 'absolute',
+    right: 16,
+    bottom: 16,
   },
 });


### PR DESCRIPTION
## Summary
- wrap app with PaperProvider for consistent styling
- add react-native-paper and picker dependencies
- create `CreateBubbleModal` using native picker/action sheet
- open modal from `BubblesScreen` with FAB button

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68408c9e8040832091ebf0015f33a75d