### PR TITLE
Implement bubble creation

### DIFF
--- a/src/components/Bubble.tsx
+++ b/src/components/Bubble.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
-import { Pressable } from "react-native";
-import Svg, { Circle, Text as SvgText } from "react-native-svg";
+import { Pressable, Text, StyleSheet } from "react-native";
+import Svg, { Circle } from "react-native-svg";
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -11,7 +11,6 @@ import Animated, {
 } from "react-native-reanimated";
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
-const AnimatedSvgText = Animated.createAnimatedComponent(SvgText);
 
 export type BubbleData = {
   id: string;
@@ -34,6 +33,7 @@ export default function Bubble({
   onPress,
 }: BubbleProps) {
   const angle = useSharedValue(Math.random() * Math.PI * 2);
+  const distance = useSharedValue(data.orbitRadius);
   const glow = useSharedValue(0);
 
   const intensity = Math.min(1, data.reflectionCount / 10);
@@ -47,12 +47,20 @@ export default function Bubble({
       -1,
       false,
     );
+    distance.value = withRepeat(
+      withSequence(
+        withTiming(data.orbitRadius + 10, { duration: duration / 2 }),
+        withTiming(data.orbitRadius - 10, { duration: duration / 2 }),
+      ),
+      -1,
+      true,
+    );
   }, []);
 
   const animatedStyle = useAnimatedStyle(() => {
     const r = radius + glow.value;
-    const x = centerX + data.orbitRadius * Math.cos(angle.value) - r;
-    const y = centerY + data.orbitRadius * Math.sin(angle.value) - r;
+    const x = centerX + distance.value * Math.cos(angle.value) - r;
+    const y = centerY + distance.value * Math.sin(angle.value) - r;
     return {
       position: "absolute",
       width: r * 2,
@@ -84,19 +92,21 @@ export default function Bubble({
             fill={color}
             opacity={0.9}
           />
-          <AnimatedSvgText
-            x="50%"
-            y="50%"
-            fill="#fff"
-            fontSize={12}
-            fontWeight="bold"
-            textAnchor="middle"
-            alignmentBaseline="middle"
-          >
-            {data.label}
-          </AnimatedSvgText>
         </Svg>
+        <Text style={[styles.label, { top: -radius - 4 }]}>{data.label}</Text>
       </Animated.View>
     </Pressable>
   );
 }
+
+const styles = StyleSheet.create({
+  label: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    textAlign: "center",
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "bold",
+  },
+});


### PR DESCRIPTION
## Summary
- add new bubble creation logic
- fetch bubbles from the last 24 hours and watch realtime inserts
- avoid duplicated bubbles when adding
- animate bubble orbit radius and show label above the circle

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684095c9826c8320a3cb27cce488644f