### PR TITLE
Implement native 3D bubble viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
-    "three": "^0.166.0"
+    "three": "^0.166.0",
+    "expo-three-orbit-controls": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/screens/BubblesScreen.tsx
+++ b/src/screens/BubblesScreen.tsx
@@ -1,24 +1,35 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, StyleSheet, Pressable, Text, Animated } from 'react-native';
-import { Canvas } from '@react-three/fiber';
-import { OrbitControls } from '@react-three/drei';
+import { View, StyleSheet, Pressable, Text, Animated, Dimensions } from 'react-native';
+import { GLView } from 'expo-gl';
+import { Renderer } from 'expo-three';
+import * as THREE from 'three';
+import OrbitControlsView from 'expo-three-orbit-controls';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation } from '@react-navigation/native';
 
 import { RootStackParamList } from '../navigation/RootNavigator';
 import { useAuth } from '../context/AuthContext';
 import CreateBubbleModal, { NewBubble } from '../components/CreateBubbleModal';
-import Bubble3D from '../components/Bubble3D';
 import type { BubbleData } from '../components/Bubble';
 
-const BASE_ORBIT = 60;
-const ORBIT_STEP = 50;
+const BASE_ORBIT = 100;
+const ORBIT_STEP = 80;
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Bubbles'>;
+
+type LabelPosition = { x: number; y: number; visible: boolean };
 
 export default function BubblesScreen() {
   const navigation = useNavigation<NavigationProp>();
   const { supabase } = useAuth();
+
+  const glRef = useRef<any>(null);
+  const rendererRef = useRef<Renderer>();
+  const sceneRef = useRef<THREE.Scene>();
+  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const bubbleMeshes = useRef<Record<string, THREE.Mesh>>( {} );
+  const labelPositions = useRef<Record<string, LabelPosition>>({});
+  const [cameraState, setCameraState] = useState<THREE.PerspectiveCamera | null>(null);
 
   const [bubbles, setBubbles] = useState<BubbleData[]>([]);
   const [showModal, setShowModal] = useState(false);
@@ -58,8 +69,7 @@ export default function BubblesScreen() {
         id: item.id as string,
         label: (item as any).name ?? (item as any).label ?? item.id,
         reflectionCount: (item as any).reflectionCount ?? 0,
-        orbitRadius:
-          BASE_ORBIT + idx * ORBIT_STEP + Math.random() * ORBIT_STEP * 0.4,
+        orbitRadius: BASE_ORBIT + idx * ORBIT_STEP + Math.random() * ORBIT_STEP * 0.4,
       }));
       setBubbles(withOrbit);
     };
@@ -83,10 +93,7 @@ export default function BubblesScreen() {
                 id: item.id as string,
                 label: item.label ?? item.name ?? item.id,
                 reflectionCount: item.reflectionCount ?? 0,
-                orbitRadius:
-                  BASE_ORBIT +
-                  prev.length * ORBIT_STEP +
-                  Math.random() * ORBIT_STEP * 0.4,
+                orbitRadius: BASE_ORBIT + prev.length * ORBIT_STEP + Math.random() * ORBIT_STEP * 0.4,
               },
             ];
           });
@@ -99,26 +106,101 @@ export default function BubblesScreen() {
     };
   }, []);
 
+  useEffect(() => {
+    // create meshes for new bubbles
+    if (!sceneRef.current) return;
+    for (const bubble of bubbles) {
+      if (bubbleMeshes.current[bubble.id]) continue;
+      const geometry = new THREE.SphereGeometry(1, 32, 32);
+      const scaleFactor = 1 + Math.min(bubble.reflectionCount, 20) / 10;
+      const color = new THREE.Color(`hsl(48, 100%, ${80 - bubble.reflectionCount * 2}%)`);
+      const material = new THREE.MeshStandardMaterial({ color, emissive: color, emissiveIntensity: 0.2 });
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.scale.set(scaleFactor, scaleFactor, scaleFactor);
+      sceneRef.current.add(mesh);
+      bubbleMeshes.current[bubble.id] = mesh;
+      labelPositions.current[bubble.id] = { x: 0, y: 0, visible: false };
+      (mesh as any).baseAngle = Math.random() * Math.PI * 2;
+      (mesh as any).speed = 0.2 + Math.random() * 0.1;
+      (mesh as any).orbitRadius = bubble.orbitRadius;
+      (mesh as any).id = bubble.id;
+    }
+  }, [bubbles]);
+
+  const animate = () => {
+    const renderer = rendererRef.current;
+    const scene = sceneRef.current;
+    const camera = cameraRef.current;
+    const gl = glRef.current;
+    if (!renderer || !scene || !camera || !gl) return;
+
+    const time = Date.now() / 1000;
+    for (const id in bubbleMeshes.current) {
+      const mesh: any = bubbleMeshes.current[id];
+      const t = time * mesh.speed;
+      const x = mesh.orbitRadius * Math.cos(mesh.baseAngle + t);
+      const z = mesh.orbitRadius * Math.sin(mesh.baseAngle + t);
+      const y = Math.sin(t * 0.5) * 5;
+      mesh.position.set(x, y, z);
+      const vector = mesh.position.clone();
+      vector.project(camera);
+      const { width, height } = Dimensions.get('window');
+      const px = (vector.x * 0.5 + 0.5) * width;
+      const py = (-vector.y * 0.5 + 0.5) * height;
+      labelPositions.current[id] = { x: px, y: py, visible: vector.z < 1 };
+    }
+
+    renderer.render(scene, camera);
+    gl.endFrameEXP();
+    requestAnimationFrame(animate);
+  };
+
+  const onContextCreate = async (gl: any) => {
+    glRef.current = gl;
+    const { drawingBufferWidth: width, drawingBufferHeight: height } = gl;
+    const renderer = new Renderer({ gl });
+    renderer.setSize(width, height);
+    rendererRef.current = renderer;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#111');
+    scene.fog = new THREE.Fog('#111', 100, 400);
+    sceneRef.current = scene;
+
+    const camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 1000);
+    camera.position.z = 200;
+    cameraRef.current = camera;
+    setCameraState(camera);
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+    const point = new THREE.PointLight(0xffffff, 1);
+    scene.add(point);
+
+    animate();
+  };
+
   return (
     <View style={styles.container}>
-      <Canvas
-        style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
-        camera={{ position: [0, 0, 200], fov: 60 }}
-        dpr={[1, 2]}
-      >
-        <color attach="background" args={["#111"]} />
-        <fog attach="fog" args={["#111", 100, 400]} />
-        <ambientLight intensity={0.4} />
-        <pointLight position={[0, 0, 0]} intensity={1} />
-        <OrbitControls makeDefault enablePan enableZoom enableRotate maxPolarAngle={Math.PI} minPolarAngle={0} />
-        {bubbles.map((bubble) => (
-          <Bubble3D
-            key={bubble.id}
-            data={bubble}
-            onPress={(id) => navigation.navigate('Chat', { bubbleId: id })}
-          />
-        ))}
-      </Canvas>
+      {cameraState ? (
+        <OrbitControlsView style={{ flex: 1 }} camera={cameraState}>
+          <GLView style={{ flex: 1 }} onContextCreate={onContextCreate} />
+        </OrbitControlsView>
+      ) : (
+        <GLView style={{ flex: 1 }} onContextCreate={onContextCreate} />
+      )}
+
+      {Object.entries(labelPositions.current).map(([id, pos]) => (
+        <Pressable
+          key={id}
+          style={[
+            styles.label,
+            { transform: [{ translateX: pos.x }, { translateY: pos.y }] },
+          ]}
+          onPress={() => navigation.navigate('Chat', { bubbleId: id })}
+        >
+          <Text style={styles.labelText}>{bubbles.find((b) => b.id === id)?.label}</Text>
+        </Pressable>
+      ))}
 
       <Pressable style={styles.addButton} onPress={() => setShowModal(true)}>
         <Text style={styles.addText}>+</Text>
@@ -136,8 +218,7 @@ export default function BubblesScreen() {
                 id: b.id,
                 label: b.name,
                 reflectionCount: b.reflectionCount ?? 0,
-                orbitRadius:
-                  BASE_ORBIT + prev.length * ORBIT_STEP + Math.random() * ORBIT_STEP * 0.4,
+                orbitRadius: BASE_ORBIT + prev.length * ORBIT_STEP + Math.random() * ORBIT_STEP * 0.4,
               },
             ];
           });
@@ -190,6 +271,17 @@ const styles = StyleSheet.create({
     fontSize: 32,
     lineHeight: 32,
   },
+  label: {
+    position: 'absolute',
+  },
+  labelText: {
+    color: '#fff',
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 12,
+    fontSize: 12,
+  },
   toast: {
     position: 'absolute',
     bottom: 20,
@@ -205,4 +297,3 @@ const styles = StyleSheet.create({
     borderRadius: 20,
   },
 });
-


### PR DESCRIPTION
## Summary
- switch 3D screen to `expo-three` + `expo-gl`
- add `expo-three-orbit-controls` dependency
- create `OrbitControlsView` and `GLView` scene
- render bubbles with manual Three.js meshes and show labels

## Testing
- `npx tsc --noEmit` *(fails: missing dependencies and peer conflict)*
- `npm install` *(fails: dependency resolution error)*


------
https://chatgpt.com/codex/tasks/task_e_6840a0cb3db48320aac2d21616068813